### PR TITLE
Update api versions

### DIFF
--- a/deployments/kubernetes/chart/proxyinjector/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/proxyinjector/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deployments/kubernetes/chart/proxyinjector/templates/rbac.yaml
+++ b/deployments/kubernetes/chart/proxyinjector/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "proxyinjector-name" . }}
 ---
 {{- if .Values.proxyinjector.watchGlobally }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: 
@@ -34,7 +34,7 @@ rules:
       - create
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels: 
@@ -51,7 +51,7 @@ subjects:
     name: {{ template "proxyinjector-name" . }}
     namespace: {{ .Release.Namespace }}
 {{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels: 
@@ -78,7 +78,7 @@ rules:
       - create
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels: 

--- a/deployments/kubernetes/manifests/deployment.yaml
+++ b/deployments/kubernetes/manifests/deployment.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: proxyinjector/templates/deployment.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deployments/kubernetes/manifests/manifest.yaml
+++ b/deployments/kubernetes/manifests/manifest.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: "Tiller"
   name: proxyinjector
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -43,7 +43,7 @@ rules:
   - update
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -70,7 +70,7 @@ subjects:
 
 ---
 # Source: proxyinjector/templates/deployment.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deployments/kubernetes/manifests/rbac.yaml
+++ b/deployments/kubernetes/manifests/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: "Tiller"
   name: proxyinjector
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: 
@@ -45,7 +45,7 @@ rules:
       - create
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels: 

--- a/deployments/kubernetes/proxyinjector.yaml
+++ b/deployments/kubernetes/proxyinjector.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: "Tiller"
   name: proxyinjector
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -43,7 +43,7 @@ rules:
   - update
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -70,7 +70,7 @@ subjects:
 
 ---
 # Source: proxyinjector/templates/deployment.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -106,7 +106,7 @@ spec:
 
 ---
 # Source: proxyinjector/templates/deployment.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -164,7 +164,7 @@ metadata:
     heritage: "Tiller"
   name: proxyinjector
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: 
@@ -196,7 +196,7 @@ rules:
       - create
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels: 

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TEx
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -134,6 +135,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/internal/pkg/callbacks/resourceActionFuncs.go
+++ b/internal/pkg/callbacks/resourceActionFuncs.go
@@ -1,8 +1,8 @@
 package callbacks
 
 import (
-	apps "k8s.io/api/apps/v1beta2"
-	ext "k8s.io/api/extensions/v1beta1"
+	apps "k8s.io/api/apps/v1"
+	ext "k8s.io/api/apps/v1"
 )
 
 func GetDeploymentAnnotations(resource interface{}) map[string]string {

--- a/internal/pkg/controller/controller.go
+++ b/internal/pkg/controller/controller.go
@@ -39,7 +39,7 @@ func NewController(
 	}
 
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	listWatcher := cache.NewListWatchFromClient(client.ExtensionsV1beta1().RESTClient(), resource, namespace, fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(client.AppsV1().RESTClient(), resource, namespace, fields.Everything())
 
 	indexer, informer := cache.NewIndexerInformer(listWatcher, kube.ResourceMap[resource], 0, cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.Add,

--- a/internal/pkg/handler/create.go
+++ b/internal/pkg/handler/create.go
@@ -98,13 +98,13 @@ func (r ResourceCreatedHandler) Handle(conf config.Config, resourceType string) 
 					logger.Info("checking resource type and updating...")
 					if resourceType == "deployments" {
 						logger.Info("patching deployment")
-						_, err2 = client.ExtensionsV1beta1().Deployments(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
+						_, err2 = client.AppsV1().Deployments(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
 					} else if resourceType == "daemonsets" {
 						logger.Info("patching daemonset")
-						_, err2 = client.AppsV1beta2().DaemonSets(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
+						_, err2 = client.AppsV1().DaemonSets(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
 					} else if resourceType == "statefulsets" {
 						logger.Info("patching statefulset")
-						_, err2 = client.AppsV1beta2().StatefulSets(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
+						_, err2 = client.AppsV1().StatefulSets(namespace).Patch(name, types.StrategicMergePatchType, payloadBytes)
 					} else {
 						return errors.New("unexpected resource type")
 					}

--- a/pkg/kube/resourcemapper.go
+++ b/pkg/kube/resourcemapper.go
@@ -1,7 +1,7 @@
 package kube
 
 import (
-	ext "k8s.io/api/extensions/v1beta1"
+	ext "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	//apps "k8s.io/api/apps/v1beta2"
 )


### PR DESCRIPTION
Fixes #36

Kubectl apply works now - but I haven't tested it further than that.

`~/E/P/d/kubernetes> (master|✔) $ kubectl apply -f proxyinjector.yaml
serviceaccount/proxyinjector created
clusterrole.rbac.authorization.k8s.io/proxyinjector-role created
clusterrolebinding.rbac.authorization.k8s.io/proxyinjector-role-binding created
deployment.apps/proxyinjector created
deployment.apps/proxyinjector configured
serviceaccount/proxyinjector configured
clusterrole.rbac.authorization.k8s.io/proxyinjector-role configured
clusterrolebinding.rbac.authorization.k8s.io/proxyinjector-role-binding configured
configmap/proxyinjector created
`